### PR TITLE
Minimum value for minikube installation

### DIFF
--- a/examples/values/minimum.yaml
+++ b/examples/values/minimum.yaml
@@ -1,0 +1,32 @@
+#############################################
+# Minimum deployment for developer
+# * Very small CPU, Memory resources (3GB minikube)
+# * Disable scheduler, worker
+#############################################
+
+
+spacectl:
+  enabled: false
+marketplace-assets:
+  enabled: false
+plugin:
+  enabled: true
+  scheduler: false
+  worker: false
+cost-analysis:
+  enabled: false
+notification:
+  enabled: false
+statistics:
+  enabled: true
+  scheduler: false
+  worker: false
+monitoring:
+  enabled: true
+  scheduler: false
+  worker: false
+  rest: false
+inventory:
+  enabled: true
+  scheduler: false
+  worker: false


### PR DESCRIPTION
At least, Minikube needs 3GB memory.
- Disable all scheduler, worker, and rest
- Disable cost-analysis, marketplace-assets, spacectl