### PR TITLE
Update Default Example Value to "en, UTC-0"

### DIFF
--- a/examples/initializer.yaml
+++ b/examples/initializer.yaml
@@ -10,10 +10,10 @@ main:
     domain:
       root: root
       user: spaceone
-    default_language: ko
-    default_timezone: Asia/Seoul
+    default_language: en
+    default_timezone: utc-0
     domain_owner:
       id: admin
-      password: Admin123!@#   # Change your password
+      password: Admin123!@# # Change your password
     user:
       id: system_api_key


### PR DESCRIPTION
- Set default_language to `en`
- Set default_timezone to `utc-0`

- This pull request resolve the issue of #46 