### PR TITLE
Solve metrics receiver transfrom resource nil error

### DIFF
--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -676,6 +676,8 @@ metrics:
     filters:
       metric: []
       datapoint: []
+    transforms:
+      resource: ""
 
 # Settings related to capturing and forwarding logs
 logs:


### PR DESCRIPTION
# Description
The `_configs.tpl` provided by "grafana/k8s-monitoring" checks the value of `metrics.receiver.transforms.resource` from `values.yaml` and performs linting. Since the current provided value is nil (meaning no value is set), I have filled it with an empty string.