### PR TITLE
Add helm pacakaging and publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
     paths:
-      - 'charts/**'
+      - "charts/**"
     tags:
-      - 'chart-*'
+      - "chart-*"
 
 jobs:
   release-chart:
@@ -16,8 +16,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Configure Helm
-        run: helm version
+      - name: Install Helm
+        run: |
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
 
       - name: Package Helm chart
         run: |
@@ -26,7 +29,9 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat charts/my-chart/Chart.yaml | grep version: | cut -d ' ' -f 2)
+        run: |
+          VERSION=$(cat charts/my-chart/Chart.yaml | grep version: | cut -d ' ' -f 2)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Create GitHub Release
         id: create_release
@@ -34,8 +39,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: chart-${{ steps.get_version.outputs.VERSION }}
-          release_name: Chart Release ${{ steps.get_version.outputs.VERSION }}
+          tag_name: chart-${{ env.VERSION }}
+          release_name: Chart Release ${{ env.VERSION }}
           draft: false
           prerelease: false
 
@@ -45,7 +50,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./release/my-chart-${{ steps.get_version.outputs.VERSION }}.tgz
-          asset_name: my-chart-${{ steps.get_version.outputs.VERSION }}.tgz
+          asset_path: ./release/my-chart-${{ env.VERSION }}.tgz
+          asset_name: my-chart-${{ env.VERSION }}.tgz
           asset_content_type: application/octet-stream
-

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,15 +1,51 @@
-name: Publish Helm charts
+name: Publish Helm Chart
+
 on:
   push:
-    branches: [main]
-  workflow_dispatch:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+    tags:
+      - 'chart-*'
 
 jobs:
-  publish-chart:
+  release-chart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Publish Helm charts
-        uses: stefanprodan/helm-gh-pages@master
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Configure Helm
+        run: helm version
+
+      - name: Package Helm chart
+        run: |
+          mkdir ./release
+          helm package charts/my-chart --destination ./release
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::$(cat charts/my-chart/Chart.yaml | grep version: | cut -d ' ' -f 2)
+
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: chart-${{ steps.get_version.outputs.VERSION }}
+          release_name: Chart Release ${{ steps.get_version.outputs.VERSION }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Helm chart to GitHub Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/my-chart-${{ steps.get_version.outputs.VERSION }}.tgz
+          asset_name: my-chart-${{ steps.get_version.outputs.VERSION }}.tgz
+          asset_content_type: application/octet-stream
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,7 @@ name: Publish Helm Chart
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - "charts/**"
     tags:


### PR DESCRIPTION
In the original .github/workflows setup, as soon as changes were pushed to the master branch, the .tgz files were uploaded to the gh-pages branch. However, I've modified this YAML file to instead upload the .tgz files to the release/download section, allowing them to be downloaded from there.