### PR TITLE
Helm packaging and upload to gh-pages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,68 +1,15 @@
-name: Publish Helm Charts
-
+name: Publish Helm charts
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "charts/**"
-    tags:
-      - "chart-*"
+    branches: [master]
   workflow_dispatch:
 
 jobs:
-  release-charts:
+  publish-chart:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install Helm
-        run: |
-          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-          chmod 700 get_helm.sh
-          ./get_helm.sh
-
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-          sudo apt update
-          sudo apt install gh
-
-      - name: Package and Release Helm charts
-        run: |
-          mkdir ./release
-          for chart in charts/*; do
-            if [ -d "$chart" ]; then
-              chart_name=$(basename "$chart" | tr -d '\n')
-              helm package "$chart" --destination ./release
-              chart_version=$(grep 'version:' "$chart/Chart.yaml" | cut -d ' ' -f 2 | tr -d '\n')
-              chart_file="${chart_name}-${chart_version}.tgz"
-              echo "Processing... File path: ./release/$chart_file"
-              ls -l ./release
-
-              git_tag="chart-${chart_name}-${chart_version}"
-              release_name="${chart_name} Chart Release ${chart_version}"
-
-              echo "Creating GitHub Release $release_name..."
-              gh release create "$git_tag" "./release/$chart_file" --title "$release_name" --notes "Release of $chart_name version $chart_version" --target "master"
-
-              echo "$chart_name chart released successfully."
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Git for GitHub Pages
-        run: |
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git fetch --depth=1 origin gh-pages
-          git checkout -b gh-pages origin/gh-pages
-
-      - name: Update index.yaml
-        run: |
-          helm repo index ./release --url https://github.com/cloudforet-io/charts/releases/download/ --merge ./index.yaml
-          git add ./release/index.yaml
-          git commit -s -m "Update index.yaml"
-          git push origin gh-pages
+      - uses: actions/checkout@v2
+      - name: Publish Helm charts
+        uses: stefanprodan/helm-gh-pages@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description
In the user scenario, although it's possible to download the tgz files from release/download, the workflows have been modified to enable downloading the tgz files directly from the gh-pages branch. To be more precise, you can immediately install it using the `github.com/cloudforet-io/charts` endpoint with Helm.